### PR TITLE
Complete Jekyll config updates and fix Tailwind CSS

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,51 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,24 +1,11 @@
 source "https://rubygems.org"
 
-# Default to development if JEKYLL_ENV is not set
-env = ENV['JEKYLL_ENV'] || 'development'
-
-if env == 'production'
-  gem "jekyll", "~> 3.9"
-  gem "github-pages"
-  gem "jemoji", "= 0.0.10"
-  gem "kramdown", "= 1.0.2"
-  gem "terminal-table", "~> 1.4"
-else
-  gem "jekyll", "~> 4.3"
-  gem "jekyll-remote-theme"
-  gem "jekyll-feed", "~> 0.12"
-  gem "jekyll-archives"
-  # gem 'jekyll-include-cache'
-  gem "jemoji", "~> 0.12.0"
-  # gem "jekyll-postcss"
-  # gem 'jekyll-postcss-v2', '~> 1.0', '>= 1.0.2'
-end
+# Using Jekyll 4.x with GitHub Actions for deployment
+gem "jekyll", "~> 4.3"
+gem "jekyll-remote-theme"
+gem "jekyll-feed", "~> 0.17"
+gem "jekyll-archives"
+gem "jemoji", "~> 0.13"
 
 group :jekyll_plugins do
   gem "jekyll-paginate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.3)
+    activesupport (8.1.1)
       base64
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
     bigdecimal (3.1.8)
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
-    connection_pool (2.4.1)
+    connection_pool (2.5.4)
     csv (3.3.5)
-    drb (2.2.1)
+    drb (2.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -27,7 +30,7 @@ GEM
     ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
-    gemoji (3.0.1)
+    gemoji (4.1.0)
     google-protobuf (4.33.0-x86_64-darwin)
       bigdecimal
       rake (>= 13)
@@ -77,8 +80,8 @@ GEM
     jekyll-tailwindcss (0.2.0-x86_64-linux)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    jemoji (0.12.0)
-      gemoji (~> 3.0)
+    jemoji (0.13.0)
+      gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
     json (2.16.0)
@@ -90,17 +93,17 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
-    minitest (5.23.1)
-    mutex_m (0.2.0)
-    nokogiri (1.16.5-x86_64-darwin)
+    minitest (5.26.0)
+    nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.5-x86_64-linux)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.2)
-    racc (1.8.0)
+    racc (1.8.1)
     rake (13.3.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
@@ -113,11 +116,13 @@ GEM
       google-protobuf (~> 4.31)
     sass-embedded (1.93.3-x86_64-linux-gnu)
       google-protobuf (~> 4.31)
+    securerandom (0.4.1)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
+    uri (1.1.1)
     webrick (1.8.1)
 
 PLATFORMS
@@ -128,12 +133,12 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.3)
   jekyll-archives
-  jekyll-feed (~> 0.12)
+  jekyll-feed (~> 0.17)
   jekyll-include-cache
   jekyll-paginate
   jekyll-remote-theme
   jekyll-tailwindcss (~> 0.2.0)
-  jemoji (~> 0.12.0)
+  jemoji (~> 0.13)
   kramdown (~> 2.4.0)
   kramdown-parser-gfm
   terminal-table (~> 2.0.0)

--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,7 @@ github_username: songpoemHQ
 facebook_username: songpoemHQ
 
 # Build settings
-markdown: kramdown
-remote_theme: "mmistakes/minimal-mistakes@4.27.0"
+remote_theme: "mmistakes/minimal-mistakes@4.27.3"
 # permalink: /blog/:categories/:slug/
 paginate: 5 # amount of posts to show
 paginate_path: /page:num/
@@ -129,13 +128,6 @@ defaults:
     # values:
     #   layout: single
     #   author_profile: false
-
-category_archive:
-  type: liquid
-  path: /categories/
-tag_archive:
-  type: liquid
-  path: /tags/
 
 analytics:
   provider: "google"

--- a/_includes/cta_section
+++ b/_includes/cta_section
@@ -7,5 +7,5 @@
       <meta itemprop="availability" content="http://schema.org/InStock">
       <meta itemprop="priceCurrency" content="USD"> 
     </div>
-    <a href="{{ include.url }}" class="btn">{{ include.cta_label }}</a>
+    <a href="{{ include.url }}" class="btn bg-red-50 hover:bg-red-100 transition-colors duration-300">{{ include.cta_label }}</a>
   </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,17 @@
 module.exports = {
   content: [
-    './_includes/**/*.html',
+    './_includes/**/*',
     './_layouts/**/*.html',
-    './_posts/**/*.md',
-    './_pages/**/*.html',
-    './_portfolio/**/*.md',
-    './_services/**/*.md',
-    './index.html'
+    './_posts/**/*.{md,html}',
+    './_pages/**/*.{md,html}',
+    './_portfolio/**/*.{md,html}',
+    './_services/**/*.{md,html}',
+    './_skills/**/*.{md,html}',
+    './_why_us/**/*.{md,html}',
+    './_why_us_human/**/*.{md,html}',
+    './_technologies/**/*.{md,html}',
+    './_industry/**/*.{md,html}',
+    './index.{html,md}'
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
## Jekyll Configuration Updates:
- Updated Minimal Mistakes theme from 4.27.0 to 4.27.3 (latest)
- Removed redundant 'markdown: kramdown' setting (default in Jekyll 4.x)
- Removed duplicate category_archive and tag_archive blocks
- Cleaned up _config.yml for better maintainability

## Tailwind CSS Fix:
- Fixed Tailwind content scanning to include files without extensions
- Updated tailwind.config.js to scan all _includes files (not just .html)
- Added all collection directories to content paths
- Now properly scans: _skills, _why_us, _why_us_human, _technologies, _industry
- Tested with bg-red-50, hover:bg-red-100, transition-colors, duration-300
- All Tailwind utility classes now generate correctly
- Updated CTA button to use Tailwind classes as demonstration

## Gemfile Simplification:
- Removed production/development environment split
- Unified on Jekyll 4.3+ for all environments
- Updated jemoji from 0.12.0 to 0.13.0
- Updated jekyll-feed to 0.17
- Removed outdated production gems (Jekyll 3.9, old kramdown, etc.)
- Dependencies now managed via GitHub Actions workflow

## GitHub Actions Workflow:
- Created .github/workflows/jekyll.yml for Jekyll 4.x deployment
- Configured proper permissions for GitHub Pages deployment
- Uses Ruby 3.3 with bundler caching
- Supports production builds with proper baseurl handling
- Required because GitHub Pages doesn't natively support Jekyll 4.x

## Dependencies Updated:
- activesupport: 7.1.3.3 → 8.1.1
- gemoji: 3.0.1 → 4.1.0
- nokogiri: 1.16.5 → 1.18.10
- minitest: 5.23.1 → 5.26.0
- Various other dependency updates for security and compatibility

All builds tested and passing. Tailwind CSS now fully functional.