### PR TITLE
Fix image rendering issues - Remove filters and fix PNG image sizing

### DIFF
--- a/_includes/case_studies_section
+++ b/_includes/case_studies_section
@@ -18,10 +18,10 @@
       {% if case_study.featured %}
       <div class="group bg-white rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-300 border border-gray-100 hover:border-blue-200">
         <!-- Image -->
-        <div class="relative h-48 bg-gradient-to-br from-blue-50 to-purple-50 overflow-hidden">
+        <div class="relative h-48 bg-gradient-to-br from-blue-50 to-purple-50 overflow-hidden flex items-center justify-center p-6">
           <img src="{{ case_study.image_name | prepend: '/assets/images/casestudies/' | relative_url }}"
                alt="{{ case_study.alt }}"
-               class="w-full h-full object-contain p-4 group-hover:scale-105 transition-transform duration-300">
+               class="max-w-full max-h-full object-contain group-hover:scale-105 transition-transform duration-300">
           <div class="absolute top-4 right-4 bg-white px-3 py-1 rounded-full text-xs font-semibold text-blue-600 shadow-sm">
             Featured
           </div>

--- a/_includes/services_section
+++ b/_includes/services_section
@@ -12,10 +12,10 @@
       {% for service in top_services %}
       <div class="group bg-white rounded-2xl p-8 shadow-sm hover:shadow-2xl transition-all duration-300 border border-gray-100 hover:border-purple-200 hover:-translate-y-2">
         <!-- Icon with gradient background -->
-        <div class="mb-6 flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-blue-500 to-purple-600 transform group-hover:scale-110 transition-transform duration-300">
+        <div class="mb-6 flex items-center justify-center w-20 h-20 rounded-2xl bg-gradient-to-br from-blue-500 to-purple-600 p-3 transform group-hover:scale-110 transition-transform duration-300">
           <img src="{{ service.icon | prepend: '/assets/mascot/' | relative_url }}"
                alt="{{ service.title }}"
-               class="w-10 h-10 object-contain filter brightness-0 invert">
+               class="w-full h-full object-contain">
         </div>
 
         <!-- Title -->

--- a/_includes/skills_ai_section
+++ b/_includes/skills_ai_section
@@ -9,10 +9,10 @@
       {% for skill in skills %}
       <div class="group bg-white rounded-xl p-6 shadow-sm hover:shadow-xl transition-all duration-300 border border-gray-100 hover:border-blue-300 hover:-translate-y-1" itemscope itemtype="http://schema.org/SoftwareApplication">
         <!-- Icon -->
-        <div class="flex items-center justify-center h-16 mb-4">
+        <div class="flex items-center justify-center w-16 h-16 mb-4 mx-auto">
           <img src="{{ skill.icon | prepend: '/assets/mascot/' | relative_url }}"
                alt="{{ skill.title }}"
-               class="w-12 h-12 object-contain group-hover:scale-110 transition-transform duration-300"
+               class="max-w-full max-h-full object-contain group-hover:scale-110 transition-transform duration-300"
                itemprop="image">
         </div>
 

--- a/_includes/skills_core_section
+++ b/_includes/skills_core_section
@@ -9,10 +9,10 @@
       {% for skill in skills %}
       <div class="group bg-white rounded-xl p-6 shadow-sm hover:shadow-xl transition-all duration-300 border border-gray-100 hover:border-purple-300 hover:-translate-y-1" itemscope itemtype="http://schema.org/SoftwareApplication">
         <!-- Icon -->
-        <div class="flex items-center justify-center h-16 mb-4">
+        <div class="flex items-center justify-center w-16 h-16 mb-4 mx-auto">
           <img src="{{ skill.icon | prepend: '/assets/mascot/' | relative_url }}"
                alt="{{ skill.title }}"
-               class="w-12 h-12 object-contain group-hover:scale-110 transition-transform duration-300"
+               class="max-w-full max-h-full object-contain group-hover:scale-110 transition-transform duration-300"
                itemprop="image">
         </div>
 

--- a/_includes/why_us_section
+++ b/_includes/why_us_section
@@ -9,10 +9,10 @@
       {% for service in top_whyus %}
       <div class="group bg-white rounded-2xl p-8 shadow-sm hover:shadow-xl transition-all duration-300 border border-gray-100 hover:border-blue-300 hover:-translate-y-2" itemscope itemtype="http://schema.org/Service">
         <!-- Icon -->
-        <div class="mb-6 flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-blue-400 to-indigo-500 transform group-hover:scale-110 transition-transform duration-300">
+        <div class="mb-6 flex items-center justify-center w-20 h-20 rounded-2xl bg-gradient-to-br from-blue-400 to-indigo-500 p-3 transform group-hover:scale-110 transition-transform duration-300">
           <img src="{{ service.icon | prepend: '/assets/mascot/' | relative_url }}"
                alt="{{ service.title }}"
-               class="w-10 h-10 object-contain filter brightness-0 invert"
+               class="w-full h-full object-contain"
                itemprop="image">
         </div>
 


### PR DESCRIPTION
Critical Fixes:
- Remove all 'filter brightness-0 invert' classes that ruined colored PNG images
- Fix icon sizing for large PNG files (5642x3200px images)
- Use proper container-based sizing instead of fixed w-10 h-10

Changes by Section:
- services_section: w-20 h-20 container with p-3, images use w-full h-full
- why_us_section: w-20 h-20 container with p-3, images use w-full h-full
- skills_core_section: w-16 h-16 container, images use max-w-full max-h-full
- skills_ai_section: w-16 h-16 container, images use max-w-full max-h-full
- case_studies_section: flex container with p-6, images use max-w-full max-h-full

Technical Details:
- Icons are large colored PNG files (not SVGs): songpoem-programmer.png (5642x3200)
- Previous filter made colored images unreadable
- Container-based sizing allows images to scale naturally while respecting constraints
- object-contain preserves aspect ratios

Build: Successful (22.976 seconds)
Verified: 0 occurrences of old filter classes in generated HTML