### PR TITLE
Add comprehensive !important overrides for all Tailwind width/height …

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -3,24 +3,126 @@
  * Fixes for Minimal Mistakes theme CSS conflicts
  */
 
-/* Fix image sizing - prevent theme from overriding container constraints */
+/* ========================================
+   WIDTH CLASSES - Force Tailwind sizing
+   ======================================== */
+
+.w-2 {
+  width: 0.5rem !important;
+}
+
+.w-4 {
+  width: 1rem !important;
+}
+
+.w-5 {
+  width: 1.25rem !important;
+}
+
+.w-6 {
+  width: 1.5rem !important;
+}
+
+.w-8 {
+  width: 2rem !important;
+}
+
+.w-12 {
+  width: 3rem !important;
+}
+
+.w-16 {
+  width: 4rem !important;
+}
+
+.w-20 {
+  width: 5rem !important;
+}
+
+.w-full {
+  width: 100% !important;
+}
+
+/* ========================================
+   HEIGHT CLASSES - Force Tailwind sizing
+   ======================================== */
+
+.h-2 {
+  height: 0.5rem !important;
+}
+
+.h-4 {
+  height: 1rem !important;
+}
+
+.h-5 {
+  height: 1.25rem !important;
+}
+
+.h-6 {
+  height: 1.5rem !important;
+}
+
+.h-8 {
+  height: 2rem !important;
+}
+
+.h-12 {
+  height: 3rem !important;
+}
+
+.h-16 {
+  height: 4rem !important;
+}
+
+.h-20 {
+  height: 5rem !important;
+}
+
+.h-48 {
+  height: 12rem !important;
+}
+
+.h-64 {
+  height: 16rem !important;
+}
+
+.h-full {
+  height: 100% !important;
+}
+
+/* ========================================
+   FLEX UTILITIES - Prevent shrinking
+   ======================================== */
+
+.flex-shrink-0 {
+  flex-shrink: 0 !important;
+}
+
+/* ========================================
+   MAX WIDTH/HEIGHT - Responsive sizing
+   ======================================== */
+
+.max-w-full {
+  max-width: 100% !important;
+}
+
+.max-h-full {
+  max-height: 100% !important;
+}
+
+/* ========================================
+   IMAGES INSIDE CONTAINERS
+   ======================================== */
+
 .w-20 img,
 .h-20 img,
 .w-16 img,
 .h-16 img,
-.w-12 img {
+.w-12 img,
+.w-8 img {
   height: 100% !important;
   width: 100% !important;
-}
-
-/* Ensure SVG icons respect sizing classes */
-svg.w-5,
-svg.h-5,
-svg.w-4,
-svg.h-4,
-svg.w-6,
-svg.h-6 {
-  flex-shrink: 0 !important;
 }
 
 /* Global section title styling if not covered by Tailwind */


### PR DESCRIPTION
…classes

Problem: Minimal Mistakes theme CSS was overriding Tailwind sizing classes, causing SVG icons and images to display at incorrect sizes (native dimensions instead of Tailwind class values like w-5, h-5).

Solution: Added explicit !important declarations for all width and height classes used throughout the site:
- Width classes: w-2, w-4, w-5, w-6, w-8, w-12, w-16, w-20, w-full
- Height classes: h-2, h-4, h-5, h-6, h-8, h-12, h-16, h-20, h-48, h-64, h-full
- Max sizing: max-w-full, max-h-full
- Flex utilities: flex-shrink-0

This ensures Tailwind sizing works correctly across all components including:
- SVG icons in navigation and content
- Case study card images
- Service and skills section icons
- Technology badges and buttons