### PR TITLE
Fix GitHub Actions workflow - Add Node.js for Tailwind CSS compilation

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -27,6 +27,11 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
CRITICAL FIX: Tailwind CSS was not being compiled during GitHub Pages deployment

Problem:
- Browser was showing raw @tailwind directives instead of compiled CSS
- jekyll-tailwindcss gem requires Node.js to compile Tailwind CSS
- GitHub Actions workflow only had Ruby setup, no Node.js
- Result: Deployment served uncompiled 120-byte source file instead of 36KB compiled CSS

Solution:
- Added Node.js v20 setup step to GitHub Actions workflow
- Positioned before Jekyll build step
- Now jekyll-tailwindcss can properly compile during deployment

Changes:
- Added "Setup Node.js" step using actions/setup-node@v4
- Set Node.js version to 20 (LTS)
- Placed after Ruby setup, before Pages setup

This ensures:
✓ Local builds work (Node.js v22 available)
✓ GitHub Actions builds work (Node.js v20 installed) ✓ Tailwind CSS compiles to full 36KB utility CSS
✓ Browser serves compiled CSS, not source directives